### PR TITLE
Add hooks + general code cleanup

### DIFF
--- a/lua/autorun/MakeSphericalCore.lua
+++ b/lua/autorun/MakeSphericalCore.lua
@@ -17,9 +17,6 @@ OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 AddCSLuaFile( "MakeSphericalCore.lua" )
 
-util.AddNetworkString( "MakeSpherical_AddRenderOffset" )
-util.AddNetworkString( "MakeSpherical_RemoveRenderOffset" )
-
 MakeSpherical = MakeSpherical or {}
 local MakeSpherical = MakeSpherical
 
@@ -42,6 +39,8 @@ function MakeSpherical.CanTool( ent )
 end
 
 if SERVER then
+	util.AddNetworkString( "MakeSpherical_AddRenderOffset" )
+	util.AddNetworkString( "MakeSpherical_RemoveRenderOffset" )
 
 	MakeSpherical.RenderOffsetEnts = {}
 

--- a/lua/autorun/MakeSphericalCore.lua
+++ b/lua/autorun/MakeSphericalCore.lua
@@ -39,6 +39,7 @@ function MakeSpherical.CanTool( ent )
 end
 
 if SERVER then
+
 	util.AddNetworkString( "MakeSpherical_AddRenderOffset" )
 	util.AddNetworkString( "MakeSpherical_RemoveRenderOffset" )
 

--- a/lua/autorun/MakeSphericalCore.lua
+++ b/lua/autorun/MakeSphericalCore.lua
@@ -44,6 +44,8 @@ if SERVER then
 
 	function MakeSpherical.ApplyLegacySphere( ply, ent, data )
 
+		if not hook.Run( "MakeSpherical_PreMakeSphericalLegacy", ply, ent, data ) then return end
+
 		local obb = ent:OBBMaxs() - ent:OBBMins()
 		ent.noradius = ent.noradius or math.max( obb.x, obb.y, obb.z ) / 2
 		-- This is the default radius used when left-clicked with the tool, not set by the slider.
@@ -86,9 +88,12 @@ if SERVER then
 		duplicator.StoreEntityModifier( ent, "MakeSphericalCollisions", data )
 		duplicator.ClearEntityModifier( ent, "sphere" )
 
+		hook.Run( "MakeSpherical_PostMakeSphericalLegacy", ply, ent, data )
 	end
 
 	function MakeSpherical.ApplySphericalCollisions( ply, ent, data )
+
+		if not hook.Run( "MakeSpherical_PreMakeSpherical", ply, ent, data ) then return end
 
 		local phys = ent:GetPhysicsObject()
 		local ismove = phys:IsMoveable()
@@ -139,9 +144,12 @@ if SERVER then
 		ent.noradius = data.noradius
 		duplicator.StoreEntityModifier( ent, "MakeSphericalCollisions", data )
 
+		hook.Run( "MakeSpherical_PostMakeSpherical", ply, ent, data )
 	end
 
 	function MakeSpherical.ApplySphericalCollisionsE2( ent, enabled, radius )
+
+		if not hook.Run( "MakeSpherical_PreMakeSphericalE2", ent, enabled, radius ) then return end
 
 		local phys = ent:GetPhysicsObject()
 		local mass = phys:GetMass()
@@ -178,6 +186,8 @@ if SERVER then
 			ent.noradius = data.noradius
 
 		duplicator.StoreEntityModifier( ent, "MakeSphericalCollisions", data )
+
+		hook.Run( "MakeSpherical_PostMakeSphericalE2", ent, enabled, radius )
 	end
 
 	function MakeSpherical.CopyConstraintData( ent, removeconstraints )

--- a/lua/autorun/MakeSphericalCore.lua
+++ b/lua/autorun/MakeSphericalCore.lua
@@ -91,6 +91,7 @@ if SERVER then
 		duplicator.ClearEntityModifier( ent, "sphere" )
 
 		hook.Run( "MakeSpherical_PostMakeSphericalLegacy", ply, ent, data )
+
 	end
 
 	function MakeSpherical.ApplySphericalCollisions( ply, ent, data )
@@ -147,6 +148,7 @@ if SERVER then
 		duplicator.StoreEntityModifier( ent, "MakeSphericalCollisions", data )
 
 		hook.Run( "MakeSpherical_PostMakeSpherical", ply, ent, data )
+
 	end
 
 	function MakeSpherical.ApplySphericalCollisionsE2( ent, enabled, radius )
@@ -190,6 +192,7 @@ if SERVER then
 		duplicator.StoreEntityModifier( ent, "MakeSphericalCollisions", data )
 
 		hook.Run( "MakeSpherical_PostMakeSphericalE2", ent, enabled, radius )
+
 	end
 
 	function MakeSpherical.CopyConstraintData( ent, removeconstraints )

--- a/lua/autorun/MakeSphericalCore.lua
+++ b/lua/autorun/MakeSphericalCore.lua
@@ -25,13 +25,13 @@ function MakeSpherical.CanTool( ent )
 	if (
 		not ent:IsValid()
 		or string.find( ent:GetClass(), "npc_" ) or ( ent:GetClass() == "player" )
-		or string.find( ent:GetClass(), "prop_vehicle_" ) 
+		or string.find( ent:GetClass(), "prop_vehicle_" )
 		or ( ent:GetClass() == "prop_ragdoll" )
 		or ( ent:GetMoveType() ~= MOVETYPE_VPHYSICS )
-		or ( SERVER && not ent:GetPhysicsObject():IsValid() ) )
-		
-		then return false 
-	
+		or ( SERVER and not ent:GetPhysicsObject():IsValid() ) )
+
+		then return false
+
 	end
 
 	return true
@@ -39,17 +39,17 @@ function MakeSpherical.CanTool( ent )
 end
 
 if SERVER then
-	
+
 	MakeSpherical.RenderOffsetEnts = {}
-	
+
 	function MakeSpherical.ApplyLegacySphere( ply, ent, data )
-		
+
 		local obb = ent:OBBMaxs() - ent:OBBMins()
 		ent.noradius = ent.noradius or math.max( obb.x, obb.y, obb.z ) / 2
 		-- This is the default radius used when left-clicked with the tool, not set by the slider.
 		-- It needs to be stored on the entity because it cannot be calculated after the radius has been set manually
 		-- The ent's OBB size changes when made spherical
-		
+
 		-- In case the legacy dupe is old enough to not include these
 		data.mass = ent:GetPhysicsObject():GetMass() or data.mass
 		data.noradius = data.noradius or ent.noradius
@@ -60,114 +60,114 @@ if SERVER then
 		local phys = ent:GetPhysicsObject()
 		local ismove = phys:IsMoveable()
 		local issleep = phys:IsAsleep()
-		
+
 		local radius = math.Clamp( data.radius, 1, 200 )
 		if data.enabled then
-		
+
 			ent:PhysicsInitSphere( radius, phys:GetMaterial() )
 			ent:SetCollisionBounds( Vector( -radius, -radius, -radius ), Vector( radius, radius, radius ) )
-		
+
 		else
-		
+
 			ent:PhysicsInit( SOLID_VPHYSICS )
 			ent:SetMoveType( MOVETYPE_VPHYSICS )
 			ent:SetSolid( SOLID_VPHYSICS )
-		
+
 		end
-		
+
 		-- New physobject after applying spherical collisions
-		local phys = ent:GetPhysicsObject()
+		phys = ent:GetPhysicsObject()
 		phys:SetMass( data.mass )
 		phys:EnableMotion( ismove )
 		if not issleep then phys:Wake() end
-		
+
 		ent.noradius = data.noradius
 		ent.obbcenter = data.obbcenter
 		duplicator.StoreEntityModifier( ent, "MakeSphericalCollisions", data )
 		duplicator.ClearEntityModifier( ent, "sphere" )
-	
+
 	end
-	
+
 	function MakeSpherical.ApplySphericalCollisions( ply, ent, data )
-		
+
 		local phys = ent:GetPhysicsObject()
 		local ismove = phys:IsMoveable()
 		local issleep = phys:IsAsleep()
 		local radius = math.Clamp( data.radius, 1, 200 )
-		
+
 		if data.enabled then
-		
+
 			ent:PhysicsInitSphere( radius, phys:GetMaterial() )
 			ent:SetCollisionBounds( Vector( -radius, -radius, -radius ) , Vector( radius, radius, radius ) )
-		
+
 		else
-		
+
 			ent:PhysicsInit( SOLID_VPHYSICS )
 			ent:SetMoveType( MOVETYPE_VPHYSICS )
 			ent:SetSolid( SOLID_VPHYSICS )
-		
+
 		end
-		
+
 		if data.isrenderoffset ~= 0 then
-		
+
 			umsg.Start( "MakeSphericalAddRenderOffset" )
-			
+
 				umsg.Short( ent:EntIndex() )
 				umsg.Vector( data.renderoffset )
-				
+
 			umsg.End()
-			
+
 			MakeSpherical.RenderOffsetEnts[ ent:EntIndex() ] = data.renderoffset
-			
+
 		elseif data.isrenderoffset == 0 and MakeSpherical.RenderOffsetEnts[ ent:EntIndex() ] then
-		
+
 			umsg.Start( "MakeSphericalRemoveRenderOffset" )
-			
+
 				umsg.Short( ent:EntIndex() )
-				
+
 			umsg.End()
-			
+
 		end
-		
+
 		-- New physobject after applying spherical collisions
-		local phys = ent:GetPhysicsObject()
+		phys = ent:GetPhysicsObject()
 		phys:SetMass( data.mass )
 		phys:EnableMotion( ismove )
 		if not issleep then phys:Wake() end
-		
+
 		data.radius = radius
 		ent.noradius = data.noradius
 		duplicator.StoreEntityModifier( ent, "MakeSphericalCollisions", data )
-		
+
 	end
-	
+
 	function MakeSpherical.ApplySphericalCollisionsE2( ent, enabled, radius )
-		
+
 		local phys = ent:GetPhysicsObject()
 		local mass = phys:GetMass()
 		local ismove = phys:IsMoveable()
 		local issleep = phys:IsAsleep()
-		local radius = math.Clamp( radius, 1, 200 )
-		
+		radius = math.Clamp( radius, 1, 200 )
+
 		if enabled then
-		
+
 			ent:PhysicsInitSphere( radius, phys:GetMaterial() )
 			ent:SetCollisionBounds( Vector( -radius, -radius, -radius ) , Vector( radius, radius, radius ) )
-		
+
 		else
-		
+
 			ent:PhysicsInit( SOLID_VPHYSICS )
 			ent:SetMoveType( MOVETYPE_VPHYSICS )
 			ent:SetSolid( SOLID_VPHYSICS )
-		
+
 		end
-		
+
 		-- New physobject after applying spherical collisions
-		local phys = ent:GetPhysicsObject()
+		phys = ent:GetPhysicsObject()
 		phys:SetMass( mass )
 		phys:EnableMotion( ismove )
 		if not issleep then phys:Wake() end
-		
+
 			local data = {}
 			data.enabled = true
 			data.isrenderoffset = 0
@@ -177,149 +177,149 @@ if SERVER then
 			data.renderoffset = Vector(0,0,0)
 			ent.noradius = data.noradius
 
-      duplicator.StoreEntityModifier( ent, "MakeSphericalCollisions", data )
+		duplicator.StoreEntityModifier( ent, "MakeSphericalCollisions", data )
 	end
-	
+
 	function MakeSpherical.CopyConstraintData( ent, removeconstraints )
-	
+
 		local constraintdata = {}
 		for _, v in pairs( constraint.GetTable( ent ) ) do
 
 			table.insert( constraintdata, v )
-			
+
 		end
 		if removeconstraints then constraint.RemoveAll( ent ) end
 		return constraintdata
-	
+
 	end
-	
+
 	function MakeSpherical.ApplyConstraintData( ent, constraintdata )
-	
+
 		if not ( table.Count( constraintdata ) > 0 and ent:IsValid() and ent:GetPhysicsObject():IsValid() ) then return end
-		
-		for k, constr in pairs( constraintdata ) do
-			
+
+		for _, constr in pairs( constraintdata ) do
+
 			local factory = duplicator.ConstraintType[ constr.Type ]
-			if not factory then 
-			
+			if not factory then
+
 				Msg( "MakeSpherical: Unknown constraint type '" .. constr.Type .. "', skipping\n" )
 				break
-			
+
 			end
-			
+
 			-- Set up a table with "ent1 = Entity( n )" etc etc for use with the factory function
 			local args = {}
 			for i = 1, #factory.Args do
-				
+
 				args[ i ] = constr[ factory.Args[ i ] ]
-			
+
 			end
 
 			-- GG Wire team, spelling "Ctrl" wrong
 			-- This section is just to fix stuff like wire hydraulics that need "crontollers"
 			if constr.MyCrtl then
-				
+
 				-- Apply the constraint & set all the crap wire hydraulics/winches need etc
 				local controller = Entity( constr.MyCrtl )
 				controller.constraint:Remove()
-				
+
 				if constr.Type == "WireHydraulic" then
-				
+
 					WireHydraulicTracking[ constr.MyCrtl ] = controller
-					
-				elseif constr.Type == "WireWinch" then 
-				
+
+				elseif constr.Type == "WireWinch" then
+
 					WireWinchTracking[ constr.MyCrtl ] = controller
-				
+
 				end
-			
+
 			end
-				
-			-- Apply the constraint			
+
+			-- Apply the constraint
 			local constr, misc = factory.Func( unpack( args ) )
-			
+
 			-- Wheels need their ent.Motor value set to their motor constraint
 			if ent:GetClass() == "gmod_wheel" or ent:GetClass() == "gmod_wire_wheel" then
-						
-				ent.Motor = constr 
-				
+
+				ent.Motor = constr
+
 			end
-			
+
 		end
-	
+
 	end
-	
+
 	hook.Add( "PlayerConnected", "MakeSphericalSyncOffsetTable", function( ply )
-	
+
 		for k, v in pairs( MakeSpherical.ApplySphericalCollisions ) do
-		
+
 			umsg.Start( "MakeSphericalAddRenderOffset" )
-			
+
 				umsg.Short( k )
 				umsg.Vector( v )
-			
+
 			umsg.End()
-			
+
 		end
-		
+
 	end )
-	
+
 	duplicator.RegisterEntityModifier( "sphere", MakeSpherical.ApplyLegacySphere )
 	duplicator.RegisterEntityModifier( "MakeSphericalCollisions", MakeSpherical.ApplySphericalCollisions )
-	
+
 end
 
 if CLIENT then
-	
+
 	local temp = {}
-	
+
 	usermessage.Hook( "MakeSphericalAddRenderOffset", function( um )
-		
+
 		local id = um:ReadShort()
 		local offset = um:ReadVector()
 		local ent = Entity( id )
-		
+
 		if not ent:IsValid() then
-		
+
 			temp[ id ] = offset
 			return
-			
+
 		end
-		
+
 		ent.RenderOverride = function( self )
-			
+
 			ent:SetRenderOrigin( ent:LocalToWorld( offset ) )
 			ent:SetupBones()
 			if ent.Draw then ent:Draw() else ent:DrawModel() end
 			ent:SetRenderOrigin( nil )
-		
+
 		end
-		
+
 	end )
-	
+
 	usermessage.Hook( "MakeSphericalRemoveRenderOffset", function( um )
-		
+
 		local ent = Entity( um:ReadShort() )
 		ent.RenderOverride = nil
-		
+
 	end )
-	
+
 	hook.Add( "OnEntityCreated", "MakeSphericalEntityAddedDelay", function( ent )
-		
+
 		local id = ent:EntIndex()
 		if not temp[ id ] then return end
-		
+
 		ent.RenderOverride = function( self )
-		
+
 			ent:SetRenderOrigin( offset )
 			ent:SetupBones()
 			if ent.Draw then ent:Draw() else ent:DrawModel() end
 			ent:SetRenderOrigin( nil )
-			
+
 		end
-		
+
 		temp[ id ] = nil
-		
+
 	end )
-	
+
 end

--- a/lua/autorun/MakeSphericalCore.lua
+++ b/lua/autorun/MakeSphericalCore.lua
@@ -1,4 +1,3 @@
-
 --[[
 Copyright (C) 2013 David 'Falcqn' Hepworth
 
@@ -47,7 +46,7 @@ if SERVER then
 
 	function MakeSpherical.ApplyLegacySphere( ply, ent, data )
 
-		if not hook.Run( "MakeSpherical_PreMakeSphericalLegacy", ply, ent, data ) then return end
+		if hook.Run( "MakeSpherical_PreMakeSphericalLegacy", ply, ent, data ) == false then return end
 
 		local obb = ent:OBBMaxs() - ent:OBBMins()
 		ent.noradius = ent.noradius or math.max( obb.x, obb.y, obb.z ) / 2
@@ -96,7 +95,7 @@ if SERVER then
 
 	function MakeSpherical.ApplySphericalCollisions( ply, ent, data )
 
-		if not hook.Run( "MakeSpherical_PreMakeSpherical", ply, ent, data ) then return end
+		if hook.Run( "MakeSpherical_PreMakeSpherical", ply, ent, data ) == false then return end
 
 		local phys = ent:GetPhysicsObject()
 		local ismove = phys:IsMoveable()
@@ -152,7 +151,7 @@ if SERVER then
 
 	function MakeSpherical.ApplySphericalCollisionsE2( ent, enabled, radius )
 
-		if not hook.Run( "MakeSpherical_PreMakeSphericalE2", ent, enabled, radius ) then return end
+		if hook.Run( "MakeSpherical_PreMakeSphericalE2", ent, enabled, radius ) == false then return end
 
 		local phys = ent:GetPhysicsObject()
 		local mass = phys:GetMass()

--- a/lua/autorun/MakeSphericalCore.lua
+++ b/lua/autorun/MakeSphericalCore.lua
@@ -287,7 +287,7 @@ if CLIENT then
 
 	net.Receive( "MakeSpherical_AddRenderOffset", function()
 
-		local id = net.ReadUInt()
+		local id = net.ReadUInt( 13 )
 		local offset = net.ReadVector()
 		local ent = Entity( id )
 
@@ -311,8 +311,9 @@ if CLIENT then
 
 	net.Receive( "MakeSpherical_RemoveRenderOffset", function()
 
-		local id = net.ReadUInt()
+		local id = net.ReadUInt( 13 )
 		local ent = Entity( id )
+		if not IsValid( ent ) then return end
 		ent.RenderOverride = nil
 
 	end )

--- a/lua/entities/gmod_wire_expression2/core/custom/MakeSphericalExtension.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/MakeSphericalExtension.lua
@@ -1,4 +1,3 @@
-
 --[[
 Copyright (C) 2013 David 'Falcqn' Hepworth
 

--- a/lua/weapons/gmod_tool/stools/makespherical.lua
+++ b/lua/weapons/gmod_tool/stools/makespherical.lua
@@ -1,4 +1,3 @@
-
 --[[
 Copyright (C) 2013 David 'Falcqn' Hepworth
 

--- a/lua/weapons/gmod_tool/stools/makespherical.lua
+++ b/lua/weapons/gmod_tool/stools/makespherical.lua
@@ -30,17 +30,17 @@ TOOL.ClientConVar[ "offset_z" ] 	= "0"
 TOOL.ClientConVar[ "useobbcenter" ] = "0"
 
 if CLIENT then
-	
+
 	language.Add( "tool.makespherical.name", "Spherical Collisions" )
 	language.Add( "tool.makespherical.desc", "Gives entities a spherical collisions with a defined radius" )
 	language.Add( "tool.makespherical.0", "Left click to make an entity have spherical collisions based on its size. Right click to set collisions with a custom radius" )
 	language.Add( "tool.makespherical.1", "Left click to make an entity have spherical collisions based on its size. Right click to set collisions with a custom radius" )
-	
+
 	function TOOL.BuildCPanel( panel )
-		
+
 		panel:AddControl( "Header", { Text = "#tool.makespherical.name", Description = "#tool.makespherical.desc" } )
-		
-		panel:AddControl( "Slider", 
+
+		panel:AddControl( "Slider",
 		{
 			Label 	= "Set radius: ",
 			Type 	= "Float",
@@ -48,19 +48,19 @@ if CLIENT then
 			Max 	= "200",
 			Command = "makespherical_radius"
 		})
-		
+
 		panel:AddControl( "CheckBox",
 		{
 			Label = "Offset render origin?",
 			Command = "makespherical_offset"
 		})
-		
+
 		panel:AddControl( "Label",
 		{
 			Text = "Note: This only changes the position the prop's model is drawn at, getting the position or bounding box center in Lua or in "
 					.. "E2 will give the exact same coordinates.\nThe prop's position will still be the center of the sphere."
 		})
-		
+
 		panel:AddControl( "Slider",
 		{
 			Label 	= "X Offset",
@@ -69,7 +69,7 @@ if CLIENT then
 			Max 	= "100",
 			Command = "makespherical_offset_x"
 		})
-		
+
 		panel:AddControl( "Slider",
 		{
 			Label 	= "Y Offset",
@@ -78,7 +78,7 @@ if CLIENT then
 			Max 	= "100",
 			Command = "makespherical_offset_y"
 		})
-		
+
 		panel:AddControl( "Slider",
 		{
 			Label 	= "Z Offset",
@@ -87,13 +87,13 @@ if CLIENT then
 			Max 	= "100",
 			Command = "makespherical_offset_z"
 		})
-		
+
 		panel:AddControl( "CheckBox",
 		{
 			Label = "Offset position by bounding box center instead",
 			Command = "makespherical_useobbcenter"
 		})
-	
+
 	end
 
 end
@@ -105,19 +105,19 @@ function TOOL:LeftClick( trace )
 	if CLIENT then return true end
 
 	if not ent.noradius then
-	
+
 		local OBB = ent:OBBMaxs() - ent:OBBMins()
-		ent.noradius = math.max( OBB.x, OBB.y, OBB.z) / 2 
-		
+		ent.noradius = math.max( OBB.x, OBB.y, OBB.z) / 2
+
 	end
-	
+
 	ent.obbcenter = ent.obbcenter or ent:OBBCenter()
 	local offsetvec = Vector( self:GetClientNumber( "offset_x" ), self:GetClientNumber( "offset_y" ), self:GetClientNumber( "offset_z" ) )
-	
-	local data = 
+
+	local data =
 	{
-		// I store the obbcenter and "obb radius" because they are altered when SetCollisionBounds is used
-		// This allows the spherical collisions to be reset even after duping
+		-- I store the obbcenter and "obb radius" because they are altered when SetCollisionBounds is used
+		-- This allows the spherical collisions to be reset even after duping
 		obbcenter 		= ent.obbcenter,
 		noradius 		= ent.noradius,
 		radius 			= ent.noradius,
@@ -126,11 +126,11 @@ function TOOL:LeftClick( trace )
 		isrenderoffset 	= self:GetClientNumber( "offset" ),
 		renderoffset 	= ( self:GetClientNumber( "useobbcenter" ) == 1 ) and -ent.obbcenter or offsetvec
 	}
-	
+
 	local constraintdata = MakeSpherical.CopyConstraintData( ent, true )
 	MakeSpherical.ApplySphericalCollisions( self:GetOwner(), ent, data )
 	timer.Simple( 0.01, function() MakeSpherical.ApplyConstraintData( ent, constraintdata ) end )
-		
+
 	return true
 
 end
@@ -142,18 +142,18 @@ function TOOL:RightClick( trace )
 	if CLIENT then return true end
 
 	if not ent.noradius then
-	
+
 		local OBB = ent:OBBMaxs() - ent:OBBMins()
-		ent.noradius = math.max( OBB.x, OBB.y, OBB.z) / 2 
-		
+		ent.noradius = math.max( OBB.x, OBB.y, OBB.z) / 2
+
 	end
-	
+
 	ent.obbcenter = ent.obbcenter or ent:OBBCenter()
 	local offsetvec = Vector( self:GetClientNumber( "offset_x" ), self:GetClientNumber( "offset_y" ), self:GetClientNumber( "offset_z" ) )
 
-	local data = 
+	local data =
 	{
-		obbcenter		= ent.obbcenter,							
+		obbcenter		= ent.obbcenter,
 		noradius 		= ent.noradius,
 		radius 			= self:GetClientNumber( "radius" ),
 		mass			= ent:GetPhysicsObject():GetMass(),
@@ -161,11 +161,11 @@ function TOOL:RightClick( trace )
 		isrenderoffset 	= self:GetClientNumber( "offset" ),
 		renderoffset 	= ( self:GetClientNumber( "useobbcenter" ) == 1 ) and -ent.obbcenter or offsetvec
 	}
-	
+
 	local constraintdata = MakeSpherical.CopyConstraintData( ent, true )
 	MakeSpherical.ApplySphericalCollisions( self:GetOwner(), ent, data )
 	timer.Simple( 0.01, function() MakeSpherical.ApplyConstraintData( ent, constraintdata ) end )
-	
+
 	return true
 
 end
@@ -175,17 +175,17 @@ function TOOL:Reload( trace )
 	local ent = trace.Entity
 	if not MakeSpherical.CanTool( ent ) then return false end
 	if CLIENT then return true end
-	
+
 	if not ent.noradius then
-	
+
 		local OBB = ent:OBBMaxs() - ent:OBBMins()
-		ent.noradius = math.max( OBB.x, OBB.y, OBB.z) / 2 
-		
+		ent.noradius = math.max( OBB.x, OBB.y, OBB.z) / 2
+
 	end
-	
+
 	ent.obbcenter = ent.obbcenter or ent:OBBCenter()
-	
-	local data = 
+
+	local data =
 	{
 		obbcenter 		= ent.obbcenter,
 		noradius 		= ent.noradius,
@@ -195,11 +195,11 @@ function TOOL:Reload( trace )
 		isrenderoffset 	= 0,
 		renderoffset 	= nil
 	}
-	
+
 	local constraintdata = MakeSpherical.CopyConstraintData( ent, true )
 	MakeSpherical.ApplySphericalCollisions( self:GetOwner(), ent, data )
 	timer.Simple( 0.01, function() MakeSpherical.ApplyConstraintData( ent, constraintdata ) end )
-	
+
 	return true
-	
+
 end

--- a/lua/weapons/gmod_tool/stools/makespherical.lua
+++ b/lua/weapons/gmod_tool/stools/makespherical.lua
@@ -35,10 +35,12 @@ if CLIENT then
 	language.Add( "tool.makespherical.desc", "Gives entities spherical collisions with a defined radius" )
 	language.Add( "tool.makespherical.left", "Give an entity spherical collisions based on its size" )
 	language.Add( "tool.makespherical.right", "Set collisions with a custom radius" )
+	language.Add( "tool.makespherical.reload", "Reset to original collisions" )
 
 	TOOL.Information = {
 		{ name = "left" },
-		{ name = "right" }
+		{ name = "right" },
+		{ name = "reload" }
 	}
 
 	function TOOL.BuildCPanel( panel )

--- a/lua/weapons/gmod_tool/stools/makespherical.lua
+++ b/lua/weapons/gmod_tool/stools/makespherical.lua
@@ -31,10 +31,15 @@ TOOL.ClientConVar[ "useobbcenter" ] = "0"
 
 if CLIENT then
 
-	language.Add( "tool.makespherical.name", "Spherical Collisions" )
-	language.Add( "tool.makespherical.desc", "Gives entities a spherical collisions with a defined radius" )
-	language.Add( "tool.makespherical.0", "Left click to make an entity have spherical collisions based on its size. Right click to set collisions with a custom radius" )
-	language.Add( "tool.makespherical.1", "Left click to make an entity have spherical collisions based on its size. Right click to set collisions with a custom radius" )
+	language.Add( "tool.makespherical.name", "Make Spherical" )
+	language.Add( "tool.makespherical.desc", "Gives entities spherical collisions with a defined radius" )
+	language.Add( "tool.makespherical.left", "Give an entity spherical collisions based on its size" )
+	language.Add( "tool.makespherical.right", "Set collisions with a custom radius" )
+
+	TOOL.Information = {
+		{ name = "left" },
+		{ name = "right" }
+	}
 
 	function TOOL.BuildCPanel( panel )
 


### PR DESCRIPTION
The main point of this PR is to add the following hooks that run before and after spherical collisions are applied to an entity:
- MakeSpherical_Pre/PostMakeSpherical( ply, ent, data )
- MakeSpherical_Pre/PostMakeSphericalE2( ent, enabled, radius )
- MakeSpherical_Pre/PostMakeSphericalLegacy( ply, ent, data )

Returning false in a pre-application hook will prevent the corresponding function from being run.

Additionally, a few steps were taken to spruce up the code a little bit:
- Removed all trailing whitespace
- Improved formatting and descriptions in the tool information display
- Replaced usermessages with net messages
- Fixed all other existing linter complaints

Tested everything in both P2P and a dedicated server (Linux 32-bit), so there should be no new issues introduced.